### PR TITLE
Clarified what meeting_tile does to fit more with Crystal formatting.

### DIFF
--- a/demo/main.cr
+++ b/demo/main.cr
@@ -13,7 +13,7 @@ class Player < Leafgem::Object
     @y += keyboard_check("down") ? 1 : 0
     set_camera_x(lerp(camera_x, Math.max(@x - 90, 0), 0.05))
 
-    while (meeting_tile(0, 0, 3))
+    while (meeting_tile?(0, 0, 3))
       @y -= 0.2
     end
     @y += 1

--- a/src/leafgem/object.cr
+++ b/src/leafgem/object.cr
@@ -109,7 +109,7 @@ class Leafgem::Object
     end
   end
 
-  def meeting_tile(xoffset, yoffset, tile, accuracy = 2)
+  def meeting_tile?(xoffset, yoffset, tile, accuracy = 2)
     # insert corners
     points_to_check = [
       [self.x + xoffset, self.y + yoffset],


### PR DESCRIPTION
It returns a boolean and makes more sense as `meeting_tile?`
In other languages it would have most likely been written as `isMeetingTile`, the `?` is crystals equivalent to that format.